### PR TITLE
change sudo to become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,9 @@
 - user: name=buildbot group=buildbot shell=/bin/bash generate_ssh_key=yes
 
 - command: buildbot create-master ~/master
-  sudo: yes
-  sudo_user: buildbot
+  become: true
+  become_method: su
+  become_user: buildbot
 
 - name: start buildbot
   copy:


### PR DESCRIPTION
-  sudo: yes
-  sudo_user: buildbot
is deprecated in ansible, lets use 
+  become: true
+  become_method: su
+  become_user: buildbot
'su' as method on become exect on all debian/ubuntu (netinst/live/full)